### PR TITLE
Update RBD base image and add RBD to use flexvolumes

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -17,8 +17,8 @@ RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
-RUN wget -O - https://storage.googleapis.com/golang/go1.8.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get github.com/golang/lint/golint
+RUN wget -O - https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+    go get github.com/rancher/trash && go get golang.org/x/lint/golint
 
 ENV DAPPER_SOURCE /go/src/github.com/rancher/storage/
 ENV DAPPER_OUTPUT ./bin ./dist

--- a/docker/volumeplugin/rancher.go
+++ b/docker/volumeplugin/rancher.go
@@ -33,6 +33,7 @@ var rancherDrivers = map[string]bool{
 	"rancher-nfs":      true,
 	"rancher-secrets":  true,
 	"rancher-longhorn": true,
+	"rancher-rbd":      true,
 }
 
 type RancherState struct {

--- a/package/rbd/Dockerfile
+++ b/package/rbd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ceph/base:tag-build-master-jewel-ubuntu-16.04
+FROM ceph/daemon-base:v3.1.0-stable-3.1-jewel-ubuntu-16.04-x86_64
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y jq curl kmod && \
     DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \


### PR DESCRIPTION
This PR includes the following changes:
- Update the go version to 1.11 and fix the golint url.
- Add `rancher-rbd` to rancherDrivers to sync with `rancher/agent`. The `rancherDrivers` here does not actually affect the code logic.
- Update the ceph base image. The original base image is outdated.